### PR TITLE
Variabilizar el nombre del WiFi Access Point

### DIFF
--- a/openplotter.py
+++ b/openplotter.py
@@ -376,6 +376,7 @@ class MainFrame(wx.Frame):
 		if os.path.exists(archivo): 
 			wifiarc=open(archivo,'r')
 			wfap=wifiarc.readline()
+			wifiarc.close()
 			self.wifiap.SetValue(wfap.strip())
 #===================================================
 
@@ -649,7 +650,8 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 		if os.path.exists(archivo): 
 			wifiarc=open(archivo,'r')
 			wfap=wifiarc.readline()
-		out=_('OpenPlotter'+wfap.strip()+'\n')
+			wifiarc.close()
+		out=_('OpenPlotter'+wfap+'\n')
 #========================================
 		ip_info=subprocess.check_output(['hostname', '-I'])
 		out=_(' NMEA 0183:\n')

--- a/openplotter.py
+++ b/openplotter.py
@@ -189,6 +189,11 @@ class MainFrame(wx.Frame):
 		self.passw = wx.TextCtrl(self.page3, -1, size=(100, 32), pos=(20, 120))
 		self.passw_label=wx.StaticText(self.page3, label=_('Password \nminimum 8 characters required'), pos=(140, 120))
 
+#Agregado----sin acceso a lenguaje (texto puesto en espanol)
+		self.wifiap = wx.TextCtrl(self.page3, -1, size=(100, 32), pos=(20, 155))
+		self.wifiap_label=wx.StaticText(self.page3, label=_('Dejar vacio o numero\npara el nombre del access point'), pos=(140, 155))
+#============================================
+
 		wx.StaticBox(self.page3, label=_(' Addresses '), size=(270, 265), pos=(415, 10))
 		#self.ip_info=wx.StaticText(self.page3, label='', pos=(430, 35))
 		self.ip_info = wx.TextCtrl(self.page3, -1, style=wx.TE_MULTILINE|wx.TE_READONLY, size=(260, 245), pos=(420, 25))
@@ -196,6 +201,12 @@ class MainFrame(wx.Frame):
 
 		self.button_refresh_ip =wx.Button(self.page3, label=_('Refresh'), pos=(570, 285))
 		self.Bind(wx.EVT_BUTTON, self.show_ip_info, self.button_refresh_ip)
+		
+#Agregado----sin acceso a lenguaje (texto puesto en espanol)
+		self.button_wifiap =wx.Button(self.page3, label=_('Grabar Nombre'), pos=(20, 285))
+		self.Bind(wx.EVT_BUTTON, self.cambia_wifiap, self.button_wifiap)
+#============================================
+
 ###########################page3
 ########page4###################
 		wx.StaticBox(self.page4, size=(400, 45), pos=(10, 10))
@@ -359,6 +370,14 @@ class MainFrame(wx.Frame):
 		if self.data_conf.get('STARTUP', 'gps_time')=='1': self.startup_nmea_time.SetValue(True)
 		if self.data_conf.get('STARTUP', 'x11vnc')=='1': self.startup_remote_desktop.SetValue(True)
 		if self.data_conf.get('STARTUP', 'signalk')=='1': self.startup_signalk.SetValue(True)
+
+#Agregado----- -------------------------------------
+		archivo = '/home/pi/.config/openplotter/WiFiAP.conf' 
+		if os.path.exists(archivo): 
+			wifiarc=open(archivo,'r')
+			wfap=wifiarc.readline()
+			self.wifiap.SetValue(wfap.strip())
+#===================================================
 
 		if len(self.available_wireless)>0:
 			self.wlan.SetValue(self.data_conf.get('WIFI', 'device'))
@@ -624,6 +643,14 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 		self.show_ip_info('')
 
 	def show_ip_info(self, e):
+#Agregado y Modificado--------------------
+		archivo = '/home/pi/.config/openplotter/WiFiAP.conf'
+		wfap=''
+		if os.path.exists(archivo): 
+			wifiarc=open(archivo,'r')
+			wfap=wifiarc.readline()
+		out=_('OpenPlotter'+wfap.strip()+'\n')
+#========================================
 		ip_info=subprocess.check_output(['hostname', '-I'])
 		out=_(' NMEA 0183:\n')
 		ips=ip_info.split()
@@ -658,6 +685,16 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 			self.passw_label.Enable()
 			self.wifi_enable.SetValue(False)
 			self.data_conf.set('WIFI', 'enable', '0')
+
+#Agregado----sin acceso a lenguaje (texto puesto en espanol)
+	def cambia_wifiap(self,event):
+		wfapi=self.wifiap.GetValue()
+		wifiarc=open('/home/pi/.config/openplotter/WiFiAP.conf','w')
+		wifiarc.write(wfapi)
+		wifiarc.close()
+		msg=_('Fue grabado el nombre del WiFi Access Point como:   OpenPlotter'+wfapi)
+		self.ShowMessage(msg)
+# =======================================
 
 ########SDR-AIS###################################	
 

--- a/openplotter.py
+++ b/openplotter.py
@@ -191,7 +191,7 @@ class MainFrame(wx.Frame):
 
 #Agregado----sin acceso a lenguaje (texto puesto en espanol)
 		self.wifiap = wx.TextCtrl(self.page3, -1, size=(100, 32), pos=(20, 155))
-		self.wifiap_label=wx.StaticText(self.page3, label=_('Dejar vacio o numero\npara el nombre del access point'), pos=(140, 155))
+		self.wifiap_label=wx.StaticText(self.page3, label=_('Dejar vacio o escribir un numero\npara el nombre del punto de acceso'), pos=(140, 155))
 #============================================
 
 		wx.StaticBox(self.page3, label=_(' Addresses '), size=(270, 265), pos=(415, 10))
@@ -652,6 +652,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 			wfap=wifiarc.readline()
 			wifiarc.close()
 		out=_('OpenPlotter'+wfap+'\n')
+		out+=_('____________________\n')
 #========================================
 		ip_info=subprocess.check_output(['hostname', '-I'])
 		out=_(' NMEA 0183:\n')
@@ -694,7 +695,7 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 		wifiarc=open('/home/pi/.config/openplotter/WiFiAP.conf','w')
 		wifiarc.write(wfapi)
 		wifiarc.close()
-		msg=_('Fue grabado el nombre del WiFi Access Point como:   OpenPlotter'+wfapi)
+		msg=_('Fue grabado el nombre del punto de acceso WiFi como:   OpenPlotter'+wfapi)
 		self.ShowMessage(msg)
 # =======================================
 

--- a/openplotter.py
+++ b/openplotter.py
@@ -614,6 +614,9 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 		isChecked = self.wifi_enable.GetValue()
 		wlan=self.wlan.GetValue()
 		passw=self.passw.GetValue()
+#Agregado -------------------------------
+		self.passw.Show()
+#========================================
 		if isChecked:
 			self.enable_disable_wifi(1)
 			if len(passw)>=8:
@@ -645,6 +648,11 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 
 	def show_ip_info(self, e):
 #Agregado y Modificado--------------------
+		isChecked = self.wifi_enable.GetValue()
+		if isChecked:
+			self.passw.Hide()
+		else:
+			self.passw.Show()
 		archivo = '/home/pi/.config/openplotter/WiFiAP.conf'
 		wfap=''
 		if os.path.exists(archivo): 

--- a/wifi_server.py
+++ b/wifi_server.py
@@ -38,6 +38,14 @@ if wifi_server=='1':
 	driver='nl80211'
 	chipset= 'default'
 
+#Agregado -----------------------------
+	archivo = '/home/pi/.config/openplotter/WiFiAP.conf' 
+	wfap=''
+	if os.path.exists(archivo): 
+		wifiarc=open(archivo,'r')
+		wfap=wifiarc.readline()
+#======================================
+
 	output=subprocess.check_output('lsusb')
 
 	if 'RTL8188CUS' in output:
@@ -66,7 +74,10 @@ if wifi_server=='1':
 	file.write(data)
 	file.close()
 
-	data='interface='+wlan+'\ndriver='+driver+'\nssid=OpenPlotter\nchannel=6\nwmm_enabled=1\nwpa=1\nwpa_passphrase='+passw+'\nwpa_key_mgmt=WPA-PSK\nwpa_pairwise=TKIP\nrsn_pairwise=CCMP\nauth_algs=1\nmacaddr_acl=0'
+#Modificado----------------------------
+	data='interface='+wlan+'\ndriver='+driver+'\nssid=OpenPlotter'+wfap.strip()+'\nchannel=6\nwmm_enabled=1\nwpa=1\nwpa_passphrase='+passw+'\nwpa_key_mgmt=WPA-PSK\nwpa_pairwise=TKIP\nrsn_pairwise=CCMP\nauth_algs=1\nmacaddr_acl=0'
+#======================================
+
 	file = open('/etc/hostapd/hostapd.conf', 'w')
 	file.write(data)
 	file.close()

--- a/wifi_server.py
+++ b/wifi_server.py
@@ -39,11 +39,23 @@ if wifi_server=='1':
 	chipset= 'default'
 
 #Agregado -----------------------------
-	archivo = '/home/pi/.config/openplotter/WiFiAP.conf' 
 	wfap=''
-	if os.path.exists(archivo): 
+	archivo = '/home/pi/.config/openplotter/WiFiAP.conf'
+	if os.path.exists(archivo): # si ya fue configurado en openplotter
 		wifiarc=open(archivo,'r')
 		wfap=wifiarc.readline()
+		wifiarc.close()
+	else:
+		# esto permite, para la primera vez, configurar varias microSD sin abrir OpenPlotter, directamente desde el lector, en la raiz
+		archivo = '/boot/WiFiAP.conf'
+		if os.path.exists(archivo): 
+			wifiarc=open(archivo,'r')
+			wfap=wifiarc.readline()
+			wifiarc.close()
+			# ahora grabo en localizacion principal
+			wifiarc=open('/home/pi/.config/openplotter/WiFiAP.conf','w')
+			wifiarc.write(wfap)
+			wifiarc.close()
 #======================================
 
 	output=subprocess.check_output('lsusb')


### PR DESCRIPTION
La idea es poder configurar diferentes puntos de acceso con con nombres diferentes: OpenPlotter1, Openplotter2,...etc.  Se puede crear modificando la microSD, agregándole un archivo que contiene sólo un nombre. O en OpenPlotter, una vez ingresado realizar la configuración. Si se elige la opción primera, automáticamente pasa a OpenPlotter y ya no es necesario volver a modificar la microSD.