### PR TITLE
Headless start

### DIFF
--- a/openplotter.conf
+++ b/openplotter.conf
@@ -33,5 +33,6 @@ tw_sog = 0
 [WIFI]
 enable = 0
 device = 
+ssid = 
 password = 
 

--- a/startup.py
+++ b/startup.py
@@ -21,8 +21,23 @@ home = os.path.expanduser('~')
 pathname = os.path.dirname(sys.argv[0])
 currentpath = os.path.abspath(pathname)
 
+boot_conf = ConfigParser.SafeConfigParser()
+boot_conf.read(currentpath+'/boot/config.txt')
+
+device=boot_conf.get('openplotter', 'device')
+ssid=boot_conf.get('openplotter', 'ssid')
+passw=boot_conf.get('openplotter', 'pass')
+
 data_conf = ConfigParser.SafeConfigParser()
 data_conf.read(currentpath+'/openplotter.conf')
+
+if device and ssid and passw:
+	self.data_conf.set('WIFI', 'enable', '1')
+	self.data_conf.set('WIFI', 'device', device)
+	self.data_conf.set('WIFI', 'ssid', ssid)
+	self.data_conf.set('WIFI', 'password', passw)
+	with open(currentpath+'/openplotter.conf', 'wb') as configfile:
+		self.data_conf.write(configfile)
 
 delay=int(data_conf.get('STARTUP', 'delay'))
 
@@ -41,7 +56,8 @@ channel=data_conf.get('AIS-SDR', 'channel')
 
 wifi_server=data_conf.get('WIFI', 'enable')
 wlan=data_conf.get('WIFI', 'device')
-passw=data_conf.get('WIFI', 'password')
+passw2=data_conf.get('WIFI', 'password')
+ssid2=data_conf.get('WIFI', 'ssid')
 
 nmea_mag_var=data_conf.get('STARTUP', 'nmea_mag_var')
 nmea_hdt=data_conf.get('STARTUP', 'nmea_hdt')
@@ -79,9 +95,9 @@ else:
 	subprocess.call(['pkill', '-9', 'rtl_fm'])
 	
 if wifi_server=='1':
-	subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '1', wlan, passw])
+	subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '1', wlan, passw2, ssid2])
 else:
-	subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '0', wlan, passw])
+	subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '0', wlan, passw2, ssid2])
 	
 time.sleep(16)
 

--- a/startup.py
+++ b/startup.py
@@ -21,23 +21,28 @@ home = os.path.expanduser('~')
 pathname = os.path.dirname(sys.argv[0])
 currentpath = os.path.abspath(pathname)
 
-boot_conf = ConfigParser.SafeConfigParser()
-boot_conf.read(currentpath+'/boot/config.txt')
+device=''
+ssid=''
+passw=''
 
-device=boot_conf.get('openplotter', 'device')
-ssid=boot_conf.get('openplotter', 'ssid')
-passw=boot_conf.get('openplotter', 'pass')
+try:
+	boot_conf = ConfigParser.SafeConfigParser()
+	boot_conf.read('/boot/config.txt')
+	device=boot_conf.get('OPENPLOTTER', 'device')
+	ssid=boot_conf.get('OPENPLOTTER', 'ssid')
+	passw=boot_conf.get('OPENPLOTTER', 'pass')
+except: pass
 
 data_conf = ConfigParser.SafeConfigParser()
 data_conf.read(currentpath+'/openplotter.conf')
 
 if device and ssid and passw:
-	self.data_conf.set('WIFI', 'enable', '1')
-	self.data_conf.set('WIFI', 'device', device)
-	self.data_conf.set('WIFI', 'ssid', ssid)
-	self.data_conf.set('WIFI', 'password', passw)
+	data_conf.set('WIFI', 'enable', '1')
+	data_conf.set('WIFI', 'device', device)
+	data_conf.set('WIFI', 'ssid', ssid)
+	data_conf.set('WIFI', 'password', passw)
 	with open(currentpath+'/openplotter.conf', 'wb') as configfile:
-		self.data_conf.write(configfile)
+		data_conf.write(configfile)
 
 delay=int(data_conf.get('STARTUP', 'delay'))
 

--- a/wifi_server.py
+++ b/wifi_server.py
@@ -20,6 +20,7 @@ import subprocess, ConfigParser, os, gettext, shutil, sys
 wifi_server=sys.argv[1]
 wlan = sys.argv[2]
 passw = sys.argv[3]
+ssid = sys.argv[4]
 
 pathname = os.path.dirname(sys.argv[0])
 currentpath = os.path.abspath(pathname)
@@ -66,7 +67,7 @@ if wifi_server=='1':
 	file.write(data)
 	file.close()
 
-	data='interface='+wlan+'\ndriver='+driver+'\nssid=OpenPlotter\nchannel=6\nwmm_enabled=1\nwpa=1\nwpa_passphrase='+passw+'\nwpa_key_mgmt=WPA-PSK\nwpa_pairwise=TKIP\nrsn_pairwise=CCMP\nauth_algs=1\nmacaddr_acl=0'
+	data='interface='+wlan+'\ndriver='+driver+'\nssid='+ssid+'\nchannel=6\nwmm_enabled=1\nwpa=1\nwpa_passphrase='+passw+'\nwpa_key_mgmt=WPA-PSK\nwpa_pairwise=TKIP\nrsn_pairwise=CCMP\nauth_algs=1\nmacaddr_acl=0'
 	file = open('/etc/hostapd/hostapd.conf', 'w')
 	file.write(data)
 	file.close()

--- a/wifi_server.py
+++ b/wifi_server.py
@@ -106,7 +106,7 @@ if wifi_server=='1':
 	if error==1: print "WiFi access point failed."
 	else: 
 		print "WiFi access point started.\n"
-		print "SSID: OpenPlotter"
+		print "SSID: "+ssid
 		print "Password: "+passw
 		print "Adress: 10.10.10.1"
 


### PR DESCRIPTION
If you want to use OpenPlotter without monitor and through remote desktop (headless) you will need to set the screen resolution and activate the wifi access point before running the system. To do this you have to modify /boot/config.txt file inserting your SD in any Windows, MAC or linux computer:

- Add as first line:
```
[RASPBIAN]
```
- Add after last line:
```
[OPENPLOTTER]
#uncomment to force screen resolution when monitor is not present (headless)
#framebuffer_width=800
#framebuffer_height=600
#uncomment to set WiFi access point when monitor is not present (headless)
#device=wlan0
#ssid=OpenPlotter
#pass=12345678
```