### PR TITLE
Add Sswitches

### DIFF
--- a/openplotter.conf
+++ b/openplotter.conf
@@ -40,3 +40,38 @@ device =
 ssid = 
 password = 
 
+[SWITCH1]
+enable = 0
+gpio = 
+pull_up_down = 
+on_action =
+on_command =
+off_action =
+off_command =
+
+[SWITCH2]
+enable = 0
+gpio = 
+pull_up_down = 
+on_action =
+on_command =
+off_action =
+off_command =
+
+[SWITCH3]
+enable = 0
+gpio = 
+pull_up_down = 
+on_action =
+on_command =
+off_action =
+off_command =
+
+[SWITCH4]
+enable = 0
+gpio = 
+pull_up_down = 
+on_action =
+on_command =
+off_action =
+off_command =

--- a/openplotter.conf
+++ b/openplotter.conf
@@ -50,7 +50,7 @@ off_action = 0
 off_command = 
 
 [SWITCH2]
-enable = 1
+enable = 0
 gpio =
 pull_up_down =
 on_action = 0
@@ -68,7 +68,7 @@ off_action = 0
 off_command = 
 
 [SWITCH4]
-enable = 1
+enable = 0
 gpio =
 pull_up_down =
 on_action = 0

--- a/openplotter.conf
+++ b/openplotter.conf
@@ -42,36 +42,37 @@ password =
 
 [SWITCH1]
 enable = 0
-gpio = 
-pull_up_down = 
-on_action =
-on_command =
-off_action =
-off_command =
+gpio =
+pull_up_down =
+on_action = 0
+on_command = 
+off_action = 0
+off_command = 
 
 [SWITCH2]
-enable = 0
-gpio = 
-pull_up_down = 
-on_action =
-on_command =
-off_action =
-off_command =
+enable = 1
+gpio =
+pull_up_down =
+on_action = 0
+on_command = 
+off_action = 0
+off_command = 
 
 [SWITCH3]
 enable = 0
-gpio = 
-pull_up_down = 
-on_action =
-on_command =
-off_action =
-off_command =
+gpio =
+pull_up_down =
+on_action = 0
+on_command = 
+off_action = 0
+off_command = 
 
 [SWITCH4]
-enable = 0
-gpio = 
-pull_up_down = 
-on_action =
-on_command =
-off_action =
-off_command =
+enable = 1
+gpio =
+pull_up_down =
+on_action = 0
+on_command = 
+off_action = 0
+off_command = 
+

--- a/openplotter.py
+++ b/openplotter.py
@@ -1451,9 +1451,9 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 ######################################Switches
 	def start_switches(self):
 		self.write_conf()
-		subprocess.call(['pkill', '-f', 'switches.py'])
+		subprocess.call(['sudo', 'pkill', '-f', 'switches.py'])
 		if self.switch1_enable.GetValue() or self.switch2_enable.GetValue() or self.switch3_enable.GetValue() or self.switch4_enable.GetValue():
-			subprocess.Popen(['python', currentpath+'/switches.py'])
+			subprocess.Popen(['sudo', 'python', currentpath+'/switches.py'])
 
 	def on_switch1_enable(self, e):
 		if not self.gpio_pull1.GetValue() or not self.gpio_pin1.GetValue():

--- a/openplotter.py
+++ b/openplotter.py
@@ -355,29 +355,61 @@ class MainFrame(wx.Frame):
 		self.Bind(wx.EVT_BUTTON, self.show_graph, self.button_graph)
 ###########################page6
 ########page8###################
-		self.pin_list = ['22', '23', '24', '25', '26', '27']
-		self.switch_options=[_('command'), _('reset'), _('shutdown'), _('reset NMEA 0183 multiplexer'), _('reset Signal K server'), _('toggle WiFi access point'), _('toggle SDR-AIS'), _('reset calculations'), _('reset sensors') ]
+		self.pin_list = ['22', '23', '24', '25']
+		self.switch_options=[_('command'), _('reset'), _('shutdown'), _('reset NMEA 0183 multiplexer'), _('reset Signal K server'), _('toggle WiFi access point'), _('toggle SDR-AIS') ]
+		self.pull_list = ['Pull Down', 'Pull Up']
 
-		wx.StaticBox(self.page8, label=_(' Switch 1 '), size=(330, 215), pos=(10, 10))
-		self.switch1_enable = wx.CheckBox(self.page8, label=_('Enable switch 1'), pos=(20, 35))
+		wx.StaticBox(self.page8, label=_(' Switch 1 '), size=(330, 145), pos=(10, 10))
+		self.switch1_enable = wx.CheckBox(self.page8, label=_('Enable'), pos=(20, 32))
 		self.switch1_enable.Bind(wx.EVT_CHECKBOX, self.on_switch1_enable)
-		wx.StaticText(self.page8, label=_('GPIO'), pos=(20, 80))
-		self.gpio_pin1= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(70, 32), pos=(70, 72))
-		wx.StaticText(self.page8, label=_('Action'), pos=(20, 120))
-		self.action1= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(310, 32), pos=(20, 140))
-		wx.StaticText(self.page8, label=_('command'), pos=(20, 185))
-		self.command1 = wx.TextCtrl(self.page8, -1, size=(220, 32), pos=(110, 180))
+		wx.StaticText(self.page8, label=_('GPIO'), pos=(115, 35))
+		self.gpio_pin1= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(55, 32), pos=(160, 27))
+		self.gpio_pull1= wx.ComboBox(self.page8, choices=self.pull_list, style=wx.CB_READONLY, size=(105, 32), pos=(225, 27))
+		wx.StaticText(self.page8, label=_('ON action'), pos=(20, 65))
+		self.ONaction1= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(20, 80))
+		self.ONcommand1 = wx.TextCtrl(self.page8, -1, size=(150, 32), pos=(20, 115))
+		wx.StaticText(self.page8, label=_('OFF action'), pos=(180, 65))
+		self.OFFaction1= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(180, 80))
+		self.OFFcommand1 = wx.TextCtrl(self.page8, -1, size=(150, 32), pos=(180, 115))
 
-		wx.StaticBox(self.page8, label=_(' Switch 2 '), size=(330, 215), pos=(350, 10))
-		self.switch2_enable = wx.CheckBox(self.page8, label=_('Enable switch 2'), pos=(360, 35))
+		wx.StaticBox(self.page8, label=_(' Switch 2 '), size=(330, 145), pos=(350, 10))
+		self.switch2_enable = wx.CheckBox(self.page8, label=_('Enable'), pos=(360, 32))
 		self.switch2_enable.Bind(wx.EVT_CHECKBOX, self.on_switch2_enable)
-		wx.StaticText(self.page8, label=_('GPIO'), pos=(360, 80))
-		self.gpio_pin2= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(70, 32), pos=(410, 72))
-		wx.StaticText(self.page8, label=_('Action'), pos=(360, 120))
-		self.action2= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(310, 32), pos=(360, 140))
-		wx.StaticText(self.page8, label=_('command'), pos=(360, 185))
-		self.command2 = wx.TextCtrl(self.page8, -1, size=(220, 32), pos=(450, 180))
+		wx.StaticText(self.page8, label=_('GPIO'), pos=(455, 35))
+		self.gpio_pin2= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(55, 32), pos=(500, 27))
+		self.gpio_pull2= wx.ComboBox(self.page8, choices=self.pull_list, style=wx.CB_READONLY, size=(105, 32), pos=(565, 27))
+		wx.StaticText(self.page8, label=_('ON action'), pos=(360, 65))
+		self.ONaction2= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(360, 80))
+		self.ONcommand2 = wx.TextCtrl(self.page8, -1, size=(150, 32), pos=(360, 115))
+		wx.StaticText(self.page8, label=_('OFF action'), pos=(520, 65))
+		self.OFFaction2= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(520, 80))
+		self.OFFcommand2 = wx.TextCtrl(self.page8, -1, size=(150, 32), pos=(520, 115))
 
+		wx.StaticBox(self.page8, label=_(' Switch 3 '), size=(330, 145), pos=(10, 160))
+		self.switch3_enable = wx.CheckBox(self.page8, label=_('Enable'), pos=(20, 182))
+		self.switch3_enable.Bind(wx.EVT_CHECKBOX, self.on_switch3_enable)
+		wx.StaticText(self.page8, label=_('GPIO'), pos=(115, 185))
+		self.gpio_pin3= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(55, 32), pos=(160, 177))
+		self.gpio_pull3= wx.ComboBox(self.page8, choices=self.pull_list, style=wx.CB_READONLY, size=(105, 32), pos=(225, 177))
+		wx.StaticText(self.page8, label=_('ON action'), pos=(20, 215))
+		self.ONaction3= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(20, 230))
+		self.ONcommand3 = wx.TextCtrl(self.page8, -1, size=(150, 32), pos=(20, 265))
+		wx.StaticText(self.page8, label=_('OFF action'), pos=(180, 215))
+		self.OFFaction3= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(180, 230))
+		self.OFFcommand3 = wx.TextCtrl(self.page8, -1, size=(150, 32), pos=(180, 265))
+
+		wx.StaticBox(self.page8, label=_(' Switch 4 '), size=(330, 145), pos=(350, 160))
+		self.switch4_enable = wx.CheckBox(self.page8, label=_('Enable'), pos=(360, 182))
+		self.switch4_enable.Bind(wx.EVT_CHECKBOX, self.on_switch4_enable)
+		wx.StaticText(self.page8, label=_('GPIO'), pos=(455, 185))
+		self.gpio_pin4= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(55, 32), pos=(500, 177))
+		self.gpio_pull4= wx.ComboBox(self.page8, choices=self.pull_list, style=wx.CB_READONLY, size=(105, 32), pos=(565, 177))
+		wx.StaticText(self.page8, label=_('ON action'), pos=(360, 215))
+		self.ONaction4= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(360, 230))
+		self.ONcommand4 = wx.TextCtrl(self.page8, -1, size=(150, 32), pos=(360, 265))
+		wx.StaticText(self.page8, label=_('OFF action'), pos=(520, 215))
+		self.OFFaction4= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(520, 230))
+		self.OFFcommand4 = wx.TextCtrl(self.page8, -1, size=(150, 32), pos=(520, 265))
 ###########################page8
 		self.read_kplex_conf()
 		self.set_layout_conf()
@@ -1353,11 +1385,10 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 	def on_switch2_enable(self, e):
 		pass
 
-	def	on_predefined1_enable(self, e):
+	def on_switch3_enable(self, e):
 		pass
 
-
-	def	on_predefined21_enable(self, e):
+	def on_switch4_enable(self, e):
 		pass
 #######################definitions
 

--- a/openplotter.py
+++ b/openplotter.py
@@ -356,14 +356,32 @@ class MainFrame(wx.Frame):
 ###########################page6
 ########page8###################
 		self.pin_list = ['22', '23', '24', '25']
-		self.switch_options=[_('command'), _('reset'), _('shutdown'), _('reset NMEA 0183 multiplexer'), _('reset Signal K server'), _('toggle WiFi access point'), _('toggle SDR-AIS') ]
+
+		self.switch_list=[]
+		self.switch_list.append(['0', _('nothing')])
+		self.switch_list.append(['1', _('command')])
+		self.switch_list.append(['2', _('reset')])
+		self.switch_list.append(['3', _('shutdown')])
+		self.switch_list.append(['4', _('stop NMEA multiplexer')])
+		self.switch_list.append(['5', _('start NMEA multiplexer')])
+		self.switch_list.append(['6', _('stop Signal K server')])
+		self.switch_list.append(['7', _('start Signal K server')])
+		self.switch_list.append(['8', _('stop WiFi access point')])
+		self.switch_list.append(['9', _('start WiFi access point')])
+		self.switch_list.append(['10', _('stop SDR-AIS')])
+		self.switch_list.append(['11', _('start SDR-AIS')])
+
+		self.switch_options=[]
+		for i in self.switch_list:
+			self.switch_options.append(i[1])
+
 		self.pull_list = ['Pull Down', 'Pull Up']
 
 		wx.StaticBox(self.page8, label=_(' Switch 1 '), size=(330, 145), pos=(10, 10))
 		self.switch1_enable = wx.CheckBox(self.page8, label=_('Enable'), pos=(20, 32))
 		self.switch1_enable.Bind(wx.EVT_CHECKBOX, self.on_switch1_enable)
 		wx.StaticText(self.page8, label=_('GPIO'), pos=(115, 35))
-		self.gpio_pin1= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(55, 32), pos=(160, 27))
+		self.gpio_pin1= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(60, 32), pos=(155, 27))
 		self.gpio_pull1= wx.ComboBox(self.page8, choices=self.pull_list, style=wx.CB_READONLY, size=(105, 32), pos=(225, 27))
 		wx.StaticText(self.page8, label=_('ON action'), pos=(20, 65))
 		self.ONaction1= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(20, 80))
@@ -376,7 +394,7 @@ class MainFrame(wx.Frame):
 		self.switch2_enable = wx.CheckBox(self.page8, label=_('Enable'), pos=(360, 32))
 		self.switch2_enable.Bind(wx.EVT_CHECKBOX, self.on_switch2_enable)
 		wx.StaticText(self.page8, label=_('GPIO'), pos=(455, 35))
-		self.gpio_pin2= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(55, 32), pos=(500, 27))
+		self.gpio_pin2= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(60, 32), pos=(495, 27))
 		self.gpio_pull2= wx.ComboBox(self.page8, choices=self.pull_list, style=wx.CB_READONLY, size=(105, 32), pos=(565, 27))
 		wx.StaticText(self.page8, label=_('ON action'), pos=(360, 65))
 		self.ONaction2= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(360, 80))
@@ -389,7 +407,7 @@ class MainFrame(wx.Frame):
 		self.switch3_enable = wx.CheckBox(self.page8, label=_('Enable'), pos=(20, 182))
 		self.switch3_enable.Bind(wx.EVT_CHECKBOX, self.on_switch3_enable)
 		wx.StaticText(self.page8, label=_('GPIO'), pos=(115, 185))
-		self.gpio_pin3= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(55, 32), pos=(160, 177))
+		self.gpio_pin3= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(60, 32), pos=(155, 177))
 		self.gpio_pull3= wx.ComboBox(self.page8, choices=self.pull_list, style=wx.CB_READONLY, size=(105, 32), pos=(225, 177))
 		wx.StaticText(self.page8, label=_('ON action'), pos=(20, 215))
 		self.ONaction3= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(20, 230))
@@ -402,7 +420,7 @@ class MainFrame(wx.Frame):
 		self.switch4_enable = wx.CheckBox(self.page8, label=_('Enable'), pos=(360, 182))
 		self.switch4_enable.Bind(wx.EVT_CHECKBOX, self.on_switch4_enable)
 		wx.StaticText(self.page8, label=_('GPIO'), pos=(455, 185))
-		self.gpio_pin4= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(55, 32), pos=(500, 177))
+		self.gpio_pin4= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(60, 32), pos=(495, 177))
 		self.gpio_pull4= wx.ComboBox(self.page8, choices=self.pull_list, style=wx.CB_READONLY, size=(105, 32), pos=(565, 177))
 		wx.StaticText(self.page8, label=_('ON action'), pos=(360, 215))
 		self.ONaction4= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(150, 32), pos=(360, 230))

--- a/openplotter.py
+++ b/openplotter.py
@@ -357,23 +357,20 @@ class MainFrame(wx.Frame):
 ########page8###################
 		self.pin_list = ['22', '23', '24', '25']
 
-		self.switch_list=[]
-		self.switch_list.append(['0', _('nothing')])
-		self.switch_list.append(['1', _('command')])
-		self.switch_list.append(['2', _('reset')])
-		self.switch_list.append(['3', _('shutdown')])
-		self.switch_list.append(['4', _('stop NMEA multiplexer')])
-		self.switch_list.append(['5', _('start NMEA multiplexer')])
-		self.switch_list.append(['6', _('stop Signal K server')])
-		self.switch_list.append(['7', _('start Signal K server')])
-		self.switch_list.append(['8', _('stop WiFi access point')])
-		self.switch_list.append(['9', _('start WiFi access point')])
-		self.switch_list.append(['10', _('stop SDR-AIS')])
-		self.switch_list.append(['11', _('start SDR-AIS')])
+		self.switch_options=[None] * 12
 
-		self.switch_options=[]
-		for i in self.switch_list:
-			self.switch_options.append(i[1])
+		self.switch_options[0]= _('nothing')
+		self.switch_options[1]= _('command')
+		self.switch_options[2]= _('reset')
+		self.switch_options[3]= _('shutdown')
+		self.switch_options[4]= _('stop NMEA multiplexer')
+		self.switch_options[5]= _('start NMEA multiplexer')
+		self.switch_options[6]= _('stop Signal K server')
+		self.switch_options[7]= _('start Signal K server')
+		self.switch_options[8]= _('stop WiFi access point')
+		self.switch_options[9]= _('start WiFi access point')
+		self.switch_options[10]= _('stop SDR-AIS')
+		self.switch_options[11]= _('start SDR-AIS')
 
 		self.pull_list = ['Pull Down', 'Pull Up']
 
@@ -580,6 +577,62 @@ class MainFrame(wx.Frame):
 		if self.data_conf.get('STARTUP', 'tw_stw')=='1': self.TW_STW.SetValue(True)
 		if self.data_conf.get('STARTUP', 'tw_sog')=='1': self.TW_SOG.SetValue(True)
 
+		self.gpio_pin1.SetValue(self.data_conf.get('SWITCH1', 'gpio'))
+		self.gpio_pull1.SetValue(self.data_conf.get('SWITCH1', 'pull_up_down'))
+		self.ONaction1.SetValue(self.switch_options[int(self.data_conf.get('SWITCH1', 'on_action'))])
+		self.ONcommand1.SetValue(self.data_conf.get('SWITCH1', 'on_command'))
+		self.OFFaction1.SetValue(self.switch_options[int(self.data_conf.get('SWITCH1', 'off_action'))])
+		self.OFFcommand1.SetValue(self.data_conf.get('SWITCH1', 'off_command'))
+		if self.data_conf.get('SWITCH1', 'enable')=='1':
+			self.switch1_enable.SetValue(True)
+			self.gpio_pin1.Disable()
+			self.gpio_pull1.Disable()
+			self.ONaction1.Disable()
+			self.ONcommand1.Disable()
+			self.OFFaction1.Disable()
+			self.OFFcommand1.Disable()
+		self.gpio_pin2.SetValue(self.data_conf.get('SWITCH2', 'gpio'))
+		self.gpio_pull2.SetValue(self.data_conf.get('SWITCH2', 'pull_up_down'))
+		self.ONaction2.SetValue(self.switch_options[int(self.data_conf.get('SWITCH2', 'on_action'))])
+		self.ONcommand2.SetValue(self.data_conf.get('SWITCH2', 'on_command'))
+		self.OFFaction2.SetValue(self.switch_options[int(self.data_conf.get('SWITCH2', 'off_action'))])
+		self.OFFcommand2.SetValue(self.data_conf.get('SWITCH2', 'off_command'))
+		if self.data_conf.get('SWITCH2', 'enable')=='1':
+			self.switch2_enable.SetValue(True)
+			self.gpio_pin2.Disable()
+			self.gpio_pull2.Disable()
+			self.ONaction2.Disable()
+			self.ONcommand2.Disable()
+			self.OFFaction2.Disable()
+			self.OFFcommand2.Disable()
+		self.gpio_pin3.SetValue(self.data_conf.get('SWITCH3', 'gpio'))
+		self.gpio_pull3.SetValue(self.data_conf.get('SWITCH3', 'pull_up_down'))
+		self.ONaction3.SetValue(self.switch_options[int(self.data_conf.get('SWITCH3', 'on_action'))])
+		self.ONcommand3.SetValue(self.data_conf.get('SWITCH3', 'on_command'))
+		self.OFFaction3.SetValue(self.switch_options[int(self.data_conf.get('SWITCH3', 'off_action'))])
+		self.OFFcommand3.SetValue(self.data_conf.get('SWITCH3', 'off_command'))
+		if self.data_conf.get('SWITCH3', 'enable')=='1':
+			self.switch3_enable.SetValue(True)
+			self.gpio_pin3.Disable()
+			self.gpio_pull3.Disable()
+			self.ONaction3.Disable()
+			self.ONcommand3.Disable()
+			self.OFFaction3.Disable()
+			self.OFFcommand3.Disable()
+		self.gpio_pin4.SetValue(self.data_conf.get('SWITCH4', 'gpio'))
+		self.gpio_pull4.SetValue(self.data_conf.get('SWITCH4', 'pull_up_down'))
+		self.ONaction4.SetValue(self.switch_options[int(self.data_conf.get('SWITCH4', 'on_action'))])
+		self.ONcommand4.SetValue(self.data_conf.get('SWITCH4', 'on_command'))
+		self.OFFaction4.SetValue(self.switch_options[int(self.data_conf.get('SWITCH4', 'off_action'))])
+		self.OFFcommand4.SetValue(self.data_conf.get('SWITCH4', 'off_command'))
+		if self.data_conf.get('SWITCH4', 'enable')=='1':
+			self.switch4_enable.SetValue(True)
+			self.gpio_pin4.Disable()
+			self.gpio_pull4.Disable()
+			self.ONaction4.Disable()
+			self.ONcommand4.Disable()
+			self.OFFaction4.Disable()
+			self.OFFcommand4.Disable()
 ########MENU###################################	
 
 	def time_zone(self,event):
@@ -1396,18 +1449,183 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 		subprocess.Popen(home+'/.config/signalk-server-node/bin/nmea-from-10110', cwd=home+'/.config/signalk-server-node')
 		self.SetStatusText(_('Signal K server restarted'))
 ######################################Switches
+	def start_switches(self):
+		self.write_conf()
+		subprocess.call(['pkill', '-f', 'switches.py'])
+		if self.switch1_enable.GetValue() or self.switch2_enable.GetValue() or self.switch3_enable.GetValue() or self.switch4_enable.GetValue():
+			subprocess.Popen(['python', currentpath+'/switches.py'])
 
 	def on_switch1_enable(self, e):
-		pass
+		if not self.gpio_pull1.GetValue() or not self.gpio_pin1.GetValue():
+			self.switch1_enable.SetValue(False)
+			self.ShowMessage(_('Select a GPIO Pin and Pull Down or Pull Up.'))
+			return
+		if self.gpio_pin1.GetValue()==self.gpio_pin2.GetValue() or self.gpio_pin1.GetValue()==self.gpio_pin3.GetValue() or self.gpio_pin1.GetValue()==self.gpio_pin4.GetValue():
+			self.switch1_enable.SetValue(False)
+			self.gpio_pin1.Enable()
+			self.gpio_pull1.Enable()
+			self.ONaction1.Enable()
+			self.ONcommand1.Enable()
+			self.OFFaction1.Enable()
+			self.OFFcommand1.Enable()
+			self.ShowMessage(_('This GPIO Pin is already in use.'))
+			return
+		if self.switch1_enable.GetValue(): 
+			self.data_conf.set('SWITCH1', 'enable', '1')
+			self.data_conf.set('SWITCH1', 'gpio', self.gpio_pin1.GetValue())
+			self.data_conf.set('SWITCH1', 'pull_up_down', self.gpio_pull1.GetValue())
+			self.data_conf.set('SWITCH1', 'on_action', str(self.switch_options.index(self.ONaction1.GetValue())))
+			command=self.ONcommand1.GetValue()
+			command=command.replace('\'', '"')
+			self.data_conf.set('SWITCH1', 'on_command', command )
+			self.data_conf.set('SWITCH1', 'off_action', str(self.switch_options.index(self.OFFaction1.GetValue())))
+			command=self.OFFcommand1.GetValue()
+			command=command.replace('\'', '"')
+			self.data_conf.set('SWITCH1', 'off_command', command )
+			self.gpio_pin1.Disable()
+			self.gpio_pull1.Disable()
+			self.ONaction1.Disable()
+			self.ONcommand1.Disable()
+			self.OFFaction1.Disable()
+			self.OFFcommand1.Disable()
+		else: 
+			self.data_conf.set('SWITCH1', 'enable', '0')
+			self.gpio_pin1.Enable()
+			self.gpio_pull1.Enable()
+			self.ONaction1.Enable()
+			self.ONcommand1.Enable()
+			self.OFFaction1.Enable()
+			self.OFFcommand1.Enable()
+		self.start_switches()
 
 	def on_switch2_enable(self, e):
-		pass
+		if not self.gpio_pull2.GetValue() or not self.gpio_pin2.GetValue():
+			self.switch2_enable.SetValue(False)
+			self.ShowMessage(_('Select a GPIO Pin and Pull Down or Pull Up.'))
+			return
+		if self.gpio_pin2.GetValue()==self.gpio_pin1.GetValue() or self.gpio_pin2.GetValue()==self.gpio_pin3.GetValue() or self.gpio_pin2.GetValue()==self.gpio_pin4.GetValue():
+			self.switch2_enable.SetValue(False)
+			self.gpio_pin2.Enable()
+			self.gpio_pull2.Enable()
+			self.ONaction2.Enable()
+			self.ONcommand2.Enable()
+			self.OFFaction2.Enable()
+			self.OFFcommand2.Enable()
+			self.ShowMessage(_('This GPIO Pin is already in use.'))
+			return
+		if self.switch2_enable.GetValue(): 
+			self.data_conf.set('SWITCH2', 'enable', '1')
+			self.data_conf.set('SWITCH2', 'gpio', self.gpio_pin2.GetValue())
+			self.data_conf.set('SWITCH2', 'pull_up_down', self.gpio_pull2.GetValue())
+			self.data_conf.set('SWITCH2', 'on_action', str(self.switch_options.index(self.ONaction2.GetValue())))
+			command=self.ONcommand2.GetValue()
+			command=command.replace('\'', '"')
+			self.data_conf.set('SWITCH2', 'on_command', command )
+			self.data_conf.set('SWITCH2', 'off_action', str(self.switch_options.index(self.OFFaction2.GetValue())))
+			command=self.OFFcommand2.GetValue()
+			command=command.replace('\'', '"')
+			self.data_conf.set('SWITCH2', 'off_command', command )
+			self.gpio_pin2.Disable()
+			self.gpio_pull2.Disable()
+			self.ONaction2.Disable()
+			self.ONcommand2.Disable()
+			self.OFFaction2.Disable()
+			self.OFFcommand2.Disable()
+		else: 
+			self.data_conf.set('SWITCH2', 'enable', '0')
+			self.gpio_pin2.Enable()
+			self.gpio_pull2.Enable()
+			self.ONaction2.Enable()
+			self.ONcommand2.Enable()
+			self.OFFaction2.Enable()
+			self.OFFcommand2.Enable()
+		self.start_switches()
 
 	def on_switch3_enable(self, e):
-		pass
+		if not self.gpio_pull3.GetValue() or not self.gpio_pin3.GetValue():
+			self.switch3_enable.SetValue(False)
+			self.ShowMessage(_('Select a GPIO Pin and Pull Down or Pull Up.'))
+			return
+		if self.gpio_pin3.GetValue()==self.gpio_pin1.GetValue() or self.gpio_pin3.GetValue()==self.gpio_pin2.GetValue() or self.gpio_pin3.GetValue()==self.gpio_pin4.GetValue():
+			self.switch3_enable.SetValue(False)
+			self.gpio_pin3.Enable()
+			self.gpio_pull3.Enable()
+			self.ONaction3.Enable()
+			self.ONcommand3.Enable()
+			self.OFFaction3.Enable()
+			self.OFFcommand3.Enable()
+			self.ShowMessage(_('This GPIO Pin is already in use.'))
+			return
+		if self.switch3_enable.GetValue(): 
+			self.data_conf.set('SWITCH3', 'enable', '1')
+			self.data_conf.set('SWITCH3', 'gpio', self.gpio_pin3.GetValue())
+			self.data_conf.set('SWITCH3', 'pull_up_down', self.gpio_pull3.GetValue())
+			self.data_conf.set('SWITCH3', 'on_action', str(self.switch_options.index(self.ONaction3.GetValue())))
+			command=self.ONcommand3.GetValue()
+			command=command.replace('\'', '"')
+			self.data_conf.set('SWITCH3', 'on_command', command )
+			self.data_conf.set('SWITCH3', 'off_action', str(self.switch_options.index(self.OFFaction3.GetValue())))
+			command=self.OFFcommand3.GetValue()
+			command=command.replace('\'', '"')
+			self.data_conf.set('SWITCH3', 'off_command', command )
+			self.gpio_pin3.Disable()
+			self.gpio_pull3.Disable()
+			self.ONaction3.Disable()
+			self.ONcommand3.Disable()
+			self.OFFaction3.Disable()
+			self.OFFcommand3.Disable()
+		else: 
+			self.data_conf.set('SWITCH3', 'enable', '0')
+			self.gpio_pin3.Enable()
+			self.gpio_pull3.Enable()
+			self.ONaction3.Enable()
+			self.ONcommand3.Enable()
+			self.OFFaction3.Enable()
+			self.OFFcommand3.Enable()
+		self.start_switches()
 
 	def on_switch4_enable(self, e):
-		pass
+		if not self.gpio_pull4.GetValue() or not self.gpio_pin4.GetValue():
+			self.switch4_enable.SetValue(False)
+			self.ShowMessage(_('Select a GPIO Pin and Pull Down or Pull Up.'))
+			return
+		if self.gpio_pin4.GetValue()==self.gpio_pin1.GetValue() or self.gpio_pin4.GetValue()==self.gpio_pin2.GetValue() or self.gpio_pin4.GetValue()==self.gpio_pin3.GetValue():
+			self.switch4_enable.SetValue(False)
+			self.gpio_pin4.Enable()
+			self.gpio_pull4.Enable()
+			self.ONaction4.Enable()
+			self.ONcommand4.Enable()
+			self.OFFaction4.Enable()
+			self.OFFcommand4.Enable()
+			self.ShowMessage(_('This GPIO Pin is already in use.'))
+			return
+		if self.switch4_enable.GetValue(): 
+			self.data_conf.set('SWITCH4', 'enable', '1')
+			self.data_conf.set('SWITCH4', 'gpio', self.gpio_pin4.GetValue())
+			self.data_conf.set('SWITCH4', 'pull_up_down', self.gpio_pull4.GetValue())
+			self.data_conf.set('SWITCH4', 'on_action', str(self.switch_options.index(self.ONaction4.GetValue())))
+			command=self.ONcommand4.GetValue()
+			command=command.replace('\'', '"')
+			self.data_conf.set('SWITCH4', 'on_command', command )
+			self.data_conf.set('SWITCH4', 'off_action', str(self.switch_options.index(self.OFFaction4.GetValue())))
+			command=self.OFFcommand4.GetValue()
+			command=command.replace('\'', '"')
+			self.data_conf.set('SWITCH4', 'off_command', command )
+			self.gpio_pin4.Disable()
+			self.gpio_pull4.Disable()
+			self.ONaction4.Disable()
+			self.ONcommand4.Disable()
+			self.OFFaction4.Disable()
+			self.OFFcommand4.Disable()
+		else: 
+			self.data_conf.set('SWITCH4', 'enable', '0')
+			self.gpio_pin4.Enable()
+			self.gpio_pull4.Enable()
+			self.ONaction4.Enable()
+			self.ONcommand4.Enable()
+			self.OFFaction4.Enable()
+			self.OFFcommand4.Enable()
+		self.start_switches()
 #######################definitions
 
 

--- a/openplotter.py
+++ b/openplotter.py
@@ -364,13 +364,13 @@ class MainFrame(wx.Frame):
 		self.switch_options[2]= _('reset')
 		self.switch_options[3]= _('shutdown')
 		self.switch_options[4]= _('stop NMEA multiplexer')
-		self.switch_options[5]= _('start NMEA multiplexer')
+		self.switch_options[5]= _('reset NMEA multiplexer')
 		self.switch_options[6]= _('stop Signal K server')
-		self.switch_options[7]= _('start Signal K server')
+		self.switch_options[7]= _('reset Signal K server')
 		self.switch_options[8]= _('stop WiFi access point')
 		self.switch_options[9]= _('start WiFi access point')
 		self.switch_options[10]= _('stop SDR-AIS')
-		self.switch_options[11]= _('start SDR-AIS')
+		self.switch_options[11]= _('reset SDR-AIS')
 
 		self.pull_list = ['Pull Down', 'Pull Up']
 

--- a/openplotter.py
+++ b/openplotter.py
@@ -63,13 +63,15 @@ class MainFrame(wx.Frame):
 		self.page5 = wx.Panel(self.nb)
 		self.page6 = wx.Panel(self.nb)
 		self.page7 = wx.Panel(self.nb)
+		self.page8 = wx.Panel(self.nb)
 
 		self.nb.AddPage(self.page5, _('NMEA 0183'))
 		self.nb.AddPage(self.page7, _('Signal K (beta)'))
-		self.nb.AddPage(self.page3, _('WiFi access point'))
+		self.nb.AddPage(self.page3, _('WiFi AP'))
 		self.nb.AddPage(self.page4, _('SDR-AIS'))
 		self.nb.AddPage(self.page2, _('Calculate'))
 		self.nb.AddPage(self.page6, _('Sensors'))
+		self.nb.AddPage(self.page8, _('Switches'))
 		self.nb.AddPage(self.page1, _('Startup'))
 
 		sizer = wx.BoxSizer()
@@ -352,6 +354,31 @@ class MainFrame(wx.Frame):
 		self.button_graph =wx.Button(self.page6, label=_('Show'), pos=(475, 240))
 		self.Bind(wx.EVT_BUTTON, self.show_graph, self.button_graph)
 ###########################page6
+########page8###################
+		self.pin_list = ['22', '23', '24', '25', '26', '27']
+		self.switch_options=[_('command'), _('reset'), _('shutdown'), _('reset NMEA 0183 multiplexer'), _('reset Signal K server'), _('toggle WiFi access point'), _('toggle SDR-AIS'), _('reset calculations'), _('reset sensors') ]
+
+		wx.StaticBox(self.page8, label=_(' Switch 1 '), size=(330, 215), pos=(10, 10))
+		self.switch1_enable = wx.CheckBox(self.page8, label=_('Enable switch 1'), pos=(20, 35))
+		self.switch1_enable.Bind(wx.EVT_CHECKBOX, self.on_switch1_enable)
+		wx.StaticText(self.page8, label=_('GPIO'), pos=(20, 80))
+		self.gpio_pin1= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(70, 32), pos=(70, 72))
+		wx.StaticText(self.page8, label=_('Action'), pos=(20, 120))
+		self.action1= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(310, 32), pos=(20, 140))
+		wx.StaticText(self.page8, label=_('command'), pos=(20, 185))
+		self.command1 = wx.TextCtrl(self.page8, -1, size=(220, 32), pos=(110, 180))
+
+		wx.StaticBox(self.page8, label=_(' Switch 2 '), size=(330, 215), pos=(350, 10))
+		self.switch2_enable = wx.CheckBox(self.page8, label=_('Enable switch 2'), pos=(360, 35))
+		self.switch2_enable.Bind(wx.EVT_CHECKBOX, self.on_switch2_enable)
+		wx.StaticText(self.page8, label=_('GPIO'), pos=(360, 80))
+		self.gpio_pin2= wx.ComboBox(self.page8, choices=self.pin_list, style=wx.CB_READONLY, size=(70, 32), pos=(410, 72))
+		wx.StaticText(self.page8, label=_('Action'), pos=(360, 120))
+		self.action2= wx.ComboBox(self.page8, choices=self.switch_options, style=wx.CB_READONLY, size=(310, 32), pos=(360, 140))
+		wx.StaticText(self.page8, label=_('command'), pos=(360, 185))
+		self.command2 = wx.TextCtrl(self.page8, -1, size=(220, 32), pos=(450, 180))
+
+###########################page8
 		self.read_kplex_conf()
 		self.set_layout_conf()
 ###########################layout
@@ -1318,6 +1345,20 @@ along with this program.  If not, see http://www.gnu.org/licenses/"""
 		subprocess.call(["pkill", '-9', "node"])
 		subprocess.Popen(home+'/.config/signalk-server-node/bin/nmea-from-10110', cwd=home+'/.config/signalk-server-node')
 		self.SetStatusText(_('Signal K server restarted'))
+######################################Switches
+
+	def on_switch1_enable(self, e):
+		pass
+
+	def on_switch2_enable(self, e):
+		pass
+
+	def	on_predefined1_enable(self, e):
+		pass
+
+
+	def	on_predefined21_enable(self, e):
+		pass
 #######################definitions
 
 

--- a/startup.py
+++ b/startup.py
@@ -78,6 +78,11 @@ nmea_eng_temp=data_conf.get('STARTUP', 'nmea_eng_temp')
 TW_STW=data_conf.get('STARTUP', 'tw_stw')
 TW_SOG=data_conf.get('STARTUP', 'tw_sog')
 
+switch1=data_conf.get('SWITCH1', 'enable')
+switch2=data_conf.get('SWITCH2', 'enable')
+switch3=data_conf.get('SWITCH3', 'enable')
+switch4=data_conf.get('SWITCH4', 'enable')
+
 #######################################################
 time.sleep(delay)
 
@@ -122,8 +127,17 @@ if gps_time=='1':
 	subprocess.call(['sudo', 'python', currentpath+'/time_gps.py'])
 
 subprocess.call(['pkill', '-f', 'sensors.py'])
-if nmea_hdg=='1' or nmea_heel=='1' or nmea_press=='1' or nmea_temp_p=='1' or nmea_hum=='1' or nmea_temp_h=='1': subprocess.Popen(['python', currentpath+'/sensors.py'], cwd=currentpath+'/imu')
+if nmea_hdg=='1' or nmea_heel=='1' or nmea_press=='1' or nmea_temp_p=='1' or nmea_hum=='1' or nmea_temp_h=='1': 
+	subprocess.Popen(['python', currentpath+'/sensors.py'], cwd=currentpath+'/imu')
+
 subprocess.call(['pkill', '-f', 'sensors_b.py'])
-if nmea_eng_temp=='1': subprocess.Popen(['python', currentpath+'/sensors_b.py'])
+if nmea_eng_temp=='1': 
+	subprocess.Popen(['python', currentpath+'/sensors_b.py'])
+
 subprocess.call(['pkill', '-f', 'calculate.py'])
-if nmea_mag_var=='1' or nmea_hdt=='1' or nmea_rot=='1' or TW_STW=='1' or TW_SOG=='1': subprocess.Popen(['python', currentpath+'/calculate.py'])
+if nmea_mag_var=='1' or nmea_hdt=='1' or nmea_rot=='1' or TW_STW=='1' or TW_SOG=='1': 
+	subprocess.Popen(['python', currentpath+'/calculate.py'])
+
+subprocess.call(['sudo', 'pkill', '-f', 'switches.py'])
+if switch1=='1' or switch2=='1' or switch3=='1' or switch4=='1':
+	subprocess.Popen(['sudo', 'python', currentpath+'/switches.py'])

--- a/startup.py
+++ b/startup.py
@@ -115,12 +115,10 @@ time.sleep(16)
 
 subprocess.call(['pkill', '-9', 'kplex'])
 if kplex=='1':
-	subprocess.call(["pkill", '-9', "kplex"])
 	subprocess.Popen('kplex')        
 
 subprocess.call(["pkill", '-9', "node"])
 if signalk=='1':
-	subprocess.call(["pkill", '-9', "node"])
 	subprocess.Popen(home+'/.config/signalk-server-node/bin/nmea-from-10110', cwd=home+'/.config/signalk-server-node')       
 	
 if gps_time=='1':

--- a/switches.py
+++ b/switches.py
@@ -25,14 +25,6 @@ currentpath = os.path.abspath(pathname)
 data_conf = ConfigParser.SafeConfigParser()
 data_conf.read(currentpath+'/openplotter.conf')
 
-wlan=data_conf.get('WIFI', 'device')
-passw2=data_conf.get('WIFI', 'password')
-ssid2=data_conf.get('WIFI', 'ssid')
-
-gain=data_conf.get('AIS-SDR', 'gain')
-ppm=data_conf.get('AIS-SDR', 'ppm')
-channel=data_conf.get('AIS-SDR', 'channel')
-
 state1=False
 state2=False
 state3=False
@@ -43,13 +35,13 @@ state4=False
 #[2]= _('reset')
 #[3]= _('shutdown')
 #[4]= _('stop NMEA multiplexer')
-#[5]= _('start NMEA multiplexer')
+#[5]= _('reset NMEA multiplexer')
 #[6]= _('stop Signal K server')
-#[7]= _('start Signal K server')
+#[7]= _('reset Signal K server')
 #[8]= _('stop WiFi access point')
 #[9]= _('start WiFi access point')
 #[10]= _('stop SDR-AIS')
-#[11]= _('start SDR-AIS')
+#[11]= _('reset SDR-AIS')
 
 def switch_options(on_off,switch,option):
 	if option=='0': return
@@ -73,20 +65,33 @@ def switch_options(on_off,switch,option):
 	if option=='7':
 		subprocess.call(["pkill", '-9', "node"]) 
 		subprocess.Popen(home+'/.config/signalk-server-node/bin/nmea-from-10110', cwd=home+'/.config/signalk-server-node') 
-	if option=='8': 
+	if option=='8':
+		data_conf.read(currentpath+'/openplotter.conf')
+		wlan=data_conf.get('WIFI', 'device')
+		passw2=data_conf.get('WIFI', 'password')
+		ssid2=data_conf.get('WIFI', 'ssid')
 		subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '0', wlan, passw2, ssid2])
 		data_conf.set('WIFI', 'enable', '0')
 		write_conf()
-	if option=='9': 
+	if option=='9':
+		data_conf.read(currentpath+'/openplotter.conf')
+		wlan=data_conf.get('WIFI', 'device')
+		passw2=data_conf.get('WIFI', 'password')
+		ssid2=data_conf.get('WIFI', 'ssid')
 		subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '1', wlan, passw2, ssid2])
 		data_conf.set('WIFI', 'enable', '1')
 		write_conf()
-	if option=='10': 
+	if option=='10':
+		data_conf.read(currentpath+'/openplotter.conf')
 		subprocess.Popen(['pkill', '-9', 'aisdecoder'])
 		subprocess.Popen(['pkill', '-9', 'rtl_fm'])
 		data_conf.set('AIS-SDR', 'enable', '0')
 		write_conf()
-	if option=='11': 
+	if option=='11':
+		data_conf.read(currentpath+'/openplotter.conf')
+		gain=data_conf.get('AIS-SDR', 'gain')
+		ppm=data_conf.get('AIS-SDR', 'ppm')
+		channel=data_conf.get('AIS-SDR', 'channel')
 		subprocess.call(['pkill', '-9', 'aisdecoder'])
 		subprocess.call(['pkill', '-9', 'rtl_fm'])
 		frecuency='161975000'

--- a/switches.py
+++ b/switches.py
@@ -55,23 +55,37 @@ def switch_options(on_off,switch,option):
 	if option=='0': return
 	if option=='1':
 		command=data_conf.get('SWITCH'+switch, on_off+'_command')
-		command=command.split(' ')
-		subprocess.Popen(command)
-	if option=='2': subprocess.Popen(['sudo', 'reboot'])
-	if option=='3': subprocess.Popen(['sudo', 'halt'])
-	if option=='4': subprocess.Popen(['pkill', '-9', 'kplex'])
+		if command:
+			command=command.split(' ')
+			subprocess.Popen(command)
+		else: return
+	if option=='2': 
+		subprocess.Popen(['sudo', 'reboot'])
+	if option=='3': 
+		subprocess.Popen(['sudo', 'halt'])
+	if option=='4': 
+		subprocess.Popen(['pkill', '-9', 'kplex'])
 	if option=='5':
 		subprocess.call(['pkill', '-9', 'kplex'])
 		subprocess.Popen('kplex')
-	if option=='6': subprocess.Popen(["pkill", '-9', "node"])
+	if option=='6': 
+		subprocess.Popen(["pkill", '-9', "node"])
 	if option=='7':
 		subprocess.call(["pkill", '-9', "node"]) 
 		subprocess.Popen(home+'/.config/signalk-server-node/bin/nmea-from-10110', cwd=home+'/.config/signalk-server-node') 
-	if option=='8': subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '0', wlan, passw2, ssid2])
-	if option=='9': subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '1', wlan, passw2, ssid2])
+	if option=='8': 
+		subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '0', wlan, passw2, ssid2])
+		data_conf.set('WIFI', 'enable', '0')
+		write_conf()
+	if option=='9': 
+		subprocess.Popen(['sudo', 'python', currentpath+'/wifi_server.py', '1', wlan, passw2, ssid2])
+		data_conf.set('WIFI', 'enable', '1')
+		write_conf()
 	if option=='10': 
 		subprocess.Popen(['pkill', '-9', 'aisdecoder'])
 		subprocess.Popen(['pkill', '-9', 'rtl_fm'])
+		data_conf.set('AIS-SDR', 'enable', '0')
+		write_conf()
 	if option=='11': 
 		subprocess.call(['pkill', '-9', 'aisdecoder'])
 		subprocess.call(['pkill', '-9', 'rtl_fm'])
@@ -79,6 +93,12 @@ def switch_options(on_off,switch,option):
 		if channel=='b': frecuency='162025000'
 		rtl_fm=subprocess.Popen(['rtl_fm', '-f', frecuency, '-g', gain, '-p', ppm, '-s', '48k'], stdout = subprocess.PIPE)
 		aisdecoder=subprocess.Popen(['aisdecoder', '-h', '127.0.0.1', '-p', '10110', '-a', 'file', '-c', 'mono', '-d', '-f', '/dev/stdin'], stdin = rtl_fm.stdout)
+		data_conf.set('AIS-SDR', 'enable', '1')
+		write_conf()
+
+def write_conf():
+	with open(currentpath+'/openplotter.conf', 'wb') as configfile:
+		data_conf.write(configfile)
 
 def switch1(channel):
 	global state1

--- a/switches.py
+++ b/switches.py
@@ -35,20 +35,73 @@ def switch1(channel):
 	global state1
 	if GPIO.input(channel):
 		if not state1:
-			print "on"
+			print "on switch 1"
 			state1=True
 	else:
 		if state1:
-			print "off"
+			print "off switch 1"
 			state1=False
 
+def switch2(channel):
+	global state2
+	if GPIO.input(channel):
+		if not state2:
+			print "on switch 2"
+			state2=True
+	else:
+		if state2:
+			print "off switch 2"
+			state2=False
+
+def switch3(channel):
+	global state3
+	if GPIO.input(channel):
+		if not state3:
+			print "on switch 3"
+			state3=True
+	else:
+		if state3:
+			print "off switch 3"
+			state3=False
+
+def switch4(channel):
+	global state4
+	if GPIO.input(channel):
+		if not state4:
+			print "on switch 4"
+			state4=True
+	else:
+		if state4:
+			print "off switch 4"
+			state4=False
+
 if data_conf.get('SWITCH1', 'enable')=='1':
-	channel=int(data_conf.get('SWITCH1', 'gpio'))
+	channel1=int(data_conf.get('SWITCH1', 'gpio'))
 	pull_up_down=GPIO.PUD_DOWN
 	if data_conf.get('SWITCH1', 'pull_up_down')=='Pull Up': pull_up_down=GPIO.PUD_UP
-	GPIO.setup(channel, GPIO.IN, pull_up_down=pull_up_down)
-	GPIO.add_event_detect(channel, GPIO.BOTH, callback=switch1)
+	GPIO.setup(channel1, GPIO.IN, pull_up_down=pull_up_down)
+	GPIO.add_event_detect(channel1, GPIO.BOTH, callback=switch1)
 
+if data_conf.get('SWITCH2', 'enable')=='1':
+	channel2=int(data_conf.get('SWITCH2', 'gpio'))
+	pull_up_down=GPIO.PUD_DOWN
+	if data_conf.get('SWITCH2', 'pull_up_down')=='Pull Up': pull_up_down=GPIO.PUD_UP
+	GPIO.setup(channel2, GPIO.IN, pull_up_down=pull_up_down)
+	GPIO.add_event_detect(channel2, GPIO.BOTH, callback=switch2)
+
+if data_conf.get('SWITCH3', 'enable')=='1':
+	channel3=int(data_conf.get('SWITCH3', 'gpio'))
+	pull_up_down=GPIO.PUD_DOWN
+	if data_conf.get('SWITCH3', 'pull_up_down')=='Pull Up': pull_up_down=GPIO.PUD_UP
+	GPIO.setup(channel3, GPIO.IN, pull_up_down=pull_up_down)
+	GPIO.add_event_detect(channel3, GPIO.BOTH, callback=switch3)
+
+if data_conf.get('SWITCH4', 'enable')=='1':
+	channel4=int(data_conf.get('SWITCH4', 'gpio'))
+	pull_up_down=GPIO.PUD_DOWN
+	if data_conf.get('SWITCH4', 'pull_up_down')=='Pull Up': pull_up_down=GPIO.PUD_UP
+	GPIO.setup(channel4, GPIO.IN, pull_up_down=pull_up_down)
+	GPIO.add_event_detect(channel4, GPIO.BOTH, callback=switch4)
 
 try:  
 	raw_input() 

--- a/switches.py
+++ b/switches.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Openplotter. If not, see <http://www.gnu.org/licenses/>.
-import ConfigParser, os, sys
+import ConfigParser, os, sys, subprocess
 import RPi.GPIO as GPIO
 from time import sleep
 
@@ -29,51 +29,69 @@ state2=False
 state3=False
 state4=False
 
-GPIO.setmode(GPIO.BCM)
+#[0]= _('nothing')
+#[1]= _('command')
+#[2]= _('reset')
+#[3]= _('shutdown')
+#[4]= _('stop NMEA multiplexer')
+#[5]= _('start NMEA multiplexer')
+#[6]= _('stop Signal K server')
+#[7]= _('start Signal K server')
+#[8]= _('stop WiFi access point')
+#[9]= _('start WiFi access point')
+#[10]= _('stop SDR-AIS')
+#[11]= _('start SDR-AIS')
+
+def switch_options(switch,option):
+	if option=='0': return
+	if option=='2': subprocess.Popen(['sudo', 'reboot'])
+	if option=='3': subprocess.Popen(['sudo', 'halt'])
 
 def switch1(channel):
 	global state1
 	if GPIO.input(channel):
 		if not state1:
-			print "on switch 1"
+			switch_options('1', data_conf.get('SWITCH1', 'on_action'))
 			state1=True
 	else:
 		if state1:
-			print "off switch 1"
+			switch_options('1', data_conf.get('SWITCH1', 'off_action'))
 			state1=False
 
 def switch2(channel):
 	global state2
 	if GPIO.input(channel):
 		if not state2:
-			print "on switch 2"
+			switch_options('2', data_conf.get('SWITCH2', 'on_action'))
 			state2=True
 	else:
 		if state2:
-			print "off switch 2"
+			switch_options('2', data_conf.get('SWITCH2', 'off_action'))
 			state2=False
 
 def switch3(channel):
 	global state3
 	if GPIO.input(channel):
 		if not state3:
-			print "on switch 3"
+			switch_options('3', data_conf.get('SWITCH3', 'on_action'))
 			state3=True
 	else:
 		if state3:
-			print "off switch 3"
+			switch_options('3', data_conf.get('SWITCH3', 'off_action'))
 			state3=False
 
 def switch4(channel):
 	global state4
 	if GPIO.input(channel):
 		if not state4:
-			print "on switch 4"
+			switch_options('4', data_conf.get('SWITCH4', 'on_action'))
 			state4=True
 	else:
 		if state4:
-			print "off switch 4"
+			switch_options('4', data_conf.get('SWITCH4', 'off_action'))
 			state4=False
+
+GPIO.setmode(GPIO.BCM)
 
 if data_conf.get('SWITCH1', 'enable')=='1':
 	channel1=int(data_conf.get('SWITCH1', 'gpio'))
@@ -104,6 +122,7 @@ if data_conf.get('SWITCH4', 'enable')=='1':
 	GPIO.add_event_detect(channel4, GPIO.BOTH, callback=switch4)
 
 try:  
-	raw_input() 
+	while True:
+		sleep(1000)
 finally:
     GPIO.cleanup()

--- a/switches.py
+++ b/switches.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+# This file is part of Openplotter.
+# Copyright (C) 2015 by sailoog <https://github.com/sailoog/openplotter>
+#
+# Openplotter is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# any later version.
+# Openplotter is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Openplotter. If not, see <http://www.gnu.org/licenses/>.
+import ConfigParser, os, sys
+import RPi.GPIO as GPIO
+from time import sleep
+
+pathname = os.path.dirname(sys.argv[0])
+currentpath = os.path.abspath(pathname)
+
+data_conf = ConfigParser.SafeConfigParser()
+data_conf.read(currentpath+'/openplotter.conf')
+
+state1=False
+state2=False
+state3=False
+state4=False
+
+GPIO.setmode(GPIO.BCM)
+
+def switch1(channel):
+	global state1
+	if GPIO.input(channel):
+		if not state1:
+			print "on"
+			state1=True
+	else:
+		if state1:
+			print "off"
+			state1=False
+
+if data_conf.get('SWITCH1', 'enable')=='1':
+	channel=int(data_conf.get('SWITCH1', 'gpio'))
+	pull_up_down=GPIO.PUD_DOWN
+	if data_conf.get('SWITCH1', 'pull_up_down')=='Pull Up': pull_up_down=GPIO.PUD_UP
+	GPIO.setup(channel, GPIO.IN, pull_up_down=pull_up_down)
+	GPIO.add_event_detect(channel, GPIO.BOTH, callback=switch1)
+
+
+try:  
+	raw_input() 
+finally:
+    GPIO.cleanup()


### PR DESCRIPTION
In order to make easier the headless use of openplotter and the interactions with the future features of Alarms and Remote monitoring, we have added the option of connecting just 4 switch to the GPIO pins and link them to one of these options:

* nothing
* command
* reset
* shutdown
* stop NMEA multiplexer
* reset NMEA multiplexer
* stop Signal K server
* reset Signal K server
* stop WiFi access point
* start WiFi access point
* stop SDR-AIS
* reset SDR-AIS

With command you can run any linux command writing in the text field. News action are coming soon. Besides normal switches, you can connect special switches like water level switches, magnetic switches and IR motion detectors.

![switches](https://cloud.githubusercontent.com/assets/8145560/10433577/474b8fd6-7113-11e5-8630-3c6f40c0cccf.png)
